### PR TITLE
Use correct background color for profile button

### DIFF
--- a/projects/movies/src/app/app-shell/app-shell.component.scss
+++ b/projects/movies/src/app/app-shell/app-shell.component.scss
@@ -5,7 +5,7 @@
   outline: none;
   border: none;
   color: var(--palette-secondary-main);
-  background-color: var(--palette-background-default);
+  background-color: var(--palette-background-paper);
   position: relative;
   display: inline-flex;
   justify-content: center;


### PR DESCRIPTION
Ensures the profile button has the same background color as the top nav-bar, especially when in dark-mode.
Before:
<img width="47" alt="Screenshot 2022-05-05 at 13 30 14" src="https://user-images.githubusercontent.com/83649639/166914595-b8f26e5a-9754-4df0-89b1-fddb0c633883.png">

After:
<img width="54" alt="Screenshot 2022-05-05 at 13 30 02" src="https://user-images.githubusercontent.com/83649639/166914608-104ba2fc-dad8-4f20-a9e8-5f2f5da945a7.png">

